### PR TITLE
Rework ISR management

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -5,11 +5,14 @@ target = "xtensa-esp32-espidf"
 linker = "ldproxy"
 # runner = "espflash --monitor" # Select this runner for espflash v1.x.x
 runner = "espflash flash --monitor" # Select this runner for espflash v2.x.x
+#rustflags = ["--cfg", "espidf_time64"]
 
 [unstable]
 build-std = ["std", "panic_abort"]
 
 [env]
 # Note: these variables are not used when using pio builder (`cargo build --features pio`)
+#ESP_IDF_VERSION = "v5.2.1"
 ESP_IDF_VERSION = "v4.4.6"
+
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rbd_dimmer"
-version = "0.1.3"
+version = "0.2.0"
 authors = ["Emeric Martineau <11473190+emeric-martineau@users.noreply.github.com>"]
 edition = "2021"
 resolver = "2"
@@ -33,12 +33,11 @@ hal = ["esp-idf-hal", "embedded-svc", "esp-idf-svc"]
 
 [dependencies]
 log = { version = ">=0.4.17", default-features = false }
-esp-idf-sys = { version = ">=0.33.7", default-features = false }
-esp-idf-hal = { version = ">=0.42.5", optional = true, default-features = false }
+esp-idf-sys = { version = ">=0.34.1", default-features = false }
+esp-idf-hal = { version = ">=0.43.1", optional = true, default-features = false }
 esp-idf-svc = { version = ">=0.47.3", optional = true, default-features = false }
 embedded-svc = { version = ">=0.26.4", optional = true, default-features = false }
 embedded-hal = ">=0.2.7"
-liquidcrystal_i2c-rs = "0.1.0"
 edge-executor = ">=0.4.0"
 
 [build-dependencies]

--- a/README.md
+++ b/README.md
@@ -27,15 +27,18 @@ CONFIG_ESP_TIMER_INTERRUPT_LEVEL=1
 unsafe {
     let zero_crossing_pin: PinDriver<'static, AnyInputPin, Input> = PinDriver::input(AnyInputPin::new(2)).unwrap();
     let d0_pin: PinDriver<'static, AnyOutputPin, Output> = PinDriver::output(AnyOutputPin::new(4)).unwrap();
-    let mut d = DimmerDevice::new(0, d0_pin);
-    d.set_power(10);
+    let id: u8 = 0;
+    let d = DimmerDevice::new(id, d0_pin);
 
     // Create Power management
     let ddm = DevicesDimmerManager::init(DevicesDimmerManagerConfig::default_50_hz(zero_crossing_pin, vec![d])).unwrap();
 
+    rbd_dimmer::set_power(id, 100).unwrap();
+
     loop {
-        let _ = ddm.wait_zero_crossing();
+        rbd_dimmer::wait_zero_crossing().unwrap();
     }
+}
 ```
 
 That's all!

--- a/README.md
+++ b/README.md
@@ -13,6 +13,14 @@ You can visit [RobotDyn Official Store](https://robotdyn.fr.aliexpress.com/store
 
 This crate works only on ESP32-WROOM-32 (2016) microcontroler.
 
+## ESP SKK config
+
+You need add in your `sdkconfig.defaults` file (at root of your rust project):
+```
+CONFIG_ESP_TIMER_SUPPORTS_ISR_DISPATCH_METHOD=y
+CONFIG_ESP_TIMER_INTERRUPT_LEVEL=1
+```
+
 ## Example
 
 ```rust

--- a/doc/HOW-IT-WORKS.md
+++ b/doc/HOW-IT-WORKS.md
@@ -12,7 +12,7 @@ When you read the characteristics of a load, you see V=230V, In=10A, P=1800W for
 
 These values are not max values but RMS values. Max value is RMS value multiplied by square root of 2.
 
-## Theorie of manage
+## Theorie of management
 
 To manage power (for example, you want use 50%, 900W, in previous example), we will turn on power only on half sinusoidal.
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -20,6 +20,8 @@ pub enum RbdDimmerErrorKind {
     TimerEvery,
     /// No dimmer found with ID
     DimmerNotFound,
+    /// Not init
+    DimmerManagerNotInit,
 }
 
 /// Uart error with type and message

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,11 +11,13 @@
 //! The `zc` sub-module works only for 50Hz voltage.
 //! 50Hz = 100 half sinusoidal per seconde => 100%
 use core::fmt;
+use std::cell::RefCell;
 use esp_idf_hal::gpio::{AnyInputPin, AnyOutputPin, Input, Output, PinDriver};
 use esp_idf_hal::task::block_on;
 use esp_idf_svc::timer::{EspISRTimerService, EspTimer};
 use esp_idf_sys::EspError;
 use std::cmp::Ordering;
+use std::sync::atomic::{AtomicU8, Ordering as aOrdering};
 use std::time::Duration;
 
 use crate::error::*;
@@ -60,23 +62,34 @@ pub mod zc;
 const HZ_50_DURATION: u8 = 100;
 // 60Hz => half sinusoidal / 100 = 0.083 ms
 const HZ_60_DURATION: u8 = 83;
-// List of manager devices
-static mut DIMMER_DEVICES: Vec<DimmerDevice> = vec![];
-
-// The device manager
-static mut DEVICES_DIMMER_MANAGER: Option<DevicesDimmerManager> = None;
 // Maximal tick value. Cannot work 100% because of the zero crossing detection timer on the same core.
-static mut TICK_MAX: u8 = 95;
+static TICK_MAX: AtomicU8 = AtomicU8::new(95);
 // Tick of device timer counter. TICK=0 means zero crossing detected.
 // If TICK=TICK_MAX, nothing happen.
-static mut TICK: u8 = 0;
+static TICK: AtomicU8 = AtomicU8::new(0);
 // Step of tick
-static mut TICK_STEP: u8 = 1;
+static TICK_STEP: AtomicU8 = AtomicU8::new(1);
 
 /// Output pin (dimmer).
 pub type OutputPin = PinDriver<'static, AnyOutputPin, Output>;
 /// Input pin (zero crossing).
 pub type InputPin = PinDriver<'static, AnyInputPin, Input>;
+
+struct GlobalDimmerManager {
+    // List of manager devices
+    devices: RefCell<Vec<DimmerDevice>>,
+    // The device manager
+    manager: RefCell<Option<DevicesDimmerManager>>,
+}
+
+unsafe impl Sync for GlobalDimmerManager {
+    
+}
+
+static GLOBAL_DIMMER_INSTANCE: GlobalDimmerManager = GlobalDimmerManager {
+    devices: RefCell::new(vec![]),
+    manager: RefCell::new(None),
+};
 
 /// This enum represent the frequency electricity.
 #[derive(Debug, Clone, PartialEq)]
@@ -87,7 +100,7 @@ pub enum Frequency {
     F60HZ,
 }
 
-// Similarly, implement `Display` for `Point2D`.
+/// Similarly, implement `Display` for `Frequency`.
 impl fmt::Display for Frequency {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
@@ -148,6 +161,10 @@ impl DimmerDevice {
             let _ = self.pin.set_low();
         }
     }
+}
+
+unsafe impl Sync for DimmerDevice {
+
 }
 
 /// Config of device manager
@@ -213,47 +230,30 @@ pub struct DevicesDimmerManager {
 }
 
 impl DevicesDimmerManager {
-    /// At first time, init the manager singleton. Else, return singleton already created.
-    /// The list of device is singleton.
-    /// Max power is 95%.
-    pub fn init(config: DevicesDimmerManagerConfig) -> Result<&'static mut Self, RbdDimmerError> {
-        Self::init_advanced(config)
-    }
-
-    /// At first time, init the manager singleton. Else, return singleton already created.
-    /// The list of device is singleton.
-    /// step_size is allow to contol if power management is do 0 to 100 by step_size.
-    /// That allow also to be create more time for ISR timer (in 50Hz always 0.1ms * step size ).
-    pub fn init_advanced(
+    /// At first time, init the manager singleton.
+    pub fn init(
         config: DevicesDimmerManagerConfig,
-    ) -> Result<&'static mut Self, RbdDimmerError> {
-        unsafe {
-            TICK_MAX = config.tick_max;
-            TICK = TICK_MAX;
+    ) -> Result<(), RbdDimmerError> {
+        TICK_MAX.store(config.tick_max, aOrdering::Relaxed);
+        TICK.store(config.tick_max, aOrdering::Relaxed);
 
-            match DEVICES_DIMMER_MANAGER.as_mut() {
-                None => match Self::initialize(config) {
-                    Ok(d) => Ok(d),
-                    Err(e) => Err(RbdDimmerError::new(
-                        RbdDimmerErrorKind::Other,
-                        format!("Fail to initialize timer. Error code: {}", e),
-                    )),
-                },
-                Some(d) => Ok(d),
-            }
+        match Self::initialize(config) {
+            Ok(d) => Ok(d),
+            Err(e) => Err(RbdDimmerError::new(
+                RbdDimmerErrorKind::Other,
+                format!("Fail to initialize timer. Error code: {}", e),
+            )),
         }
     }
 
     /// This function wait zero crossing. Zero crossing is low to high impulsion.
     #[inline(always)]
-    pub fn wait_zero_crossing(&mut self) -> Result<(), RbdDimmerError> {
+    fn wait_zero_crossing(&mut self) -> Result<(), RbdDimmerError> {
         let result = block_on(self.zero_crossing_pin.wait_for_falling_edge());
 
         match result {
             Ok(_) => {
-                unsafe {
-                    TICK = 0;
-                }
+                TICK.store(0, aOrdering::Relaxed);
                 Ok(())
             }
             Err(_) => Err(RbdDimmerError::other(String::from(
@@ -263,10 +263,8 @@ impl DevicesDimmerManager {
     }
 
     /// Stop timer
-    pub fn stop(&mut self) -> Result<bool, RbdDimmerError> {
-        unsafe {
-            TICK = TICK_MAX;
-        }
+    fn stop(&self) -> Result<bool, RbdDimmerError> {
+        TICK.store(TICK_MAX.load(aOrdering::Relaxed), aOrdering::Relaxed);
 
         match self.esp_timer.cancel() {
             Ok(status) => Ok(status),
@@ -277,29 +275,47 @@ impl DevicesDimmerManager {
         }
     }
 
-    fn initialize(config: DevicesDimmerManagerConfig) -> Result<&'static mut Self, EspError> {
+    fn initialize(config: DevicesDimmerManagerConfig) -> Result<(), EspError> {
         unsafe {
-            // Copy all devices
-            for d in config.devices {
-                DIMMER_DEVICES.push(d);
-            }
+            {       
+                let mut devices = GLOBAL_DIMMER_INSTANCE.devices.borrow_mut();
 
-            TICK_STEP = config.step_size;
+                for d in config.devices {
+                    devices.push(d);
+                }
+            } // Borrom mut is release here
+
+            TICK_STEP.store(config.step_size, aOrdering::Relaxed);
 
             let callback = || {
-                match TICK.cmp(&TICK_MAX) {
+                let tick_max = TICK_MAX.load(aOrdering::Relaxed);
+                let tick = TICK.load(aOrdering::Relaxed);
+                match tick.cmp(&tick_max) {
                     Ordering::Less => {
-                        for d in DIMMER_DEVICES.iter_mut() {
-                            // TODO check error or not?
-                            let _ = d.tick(TICK);
+                        match GLOBAL_DIMMER_INSTANCE.devices.try_borrow_mut() {
+                            Ok(mut devices) => {
+                                for d in devices.iter_mut() {
+                                    // TODO check error or not?
+                                    let _ = d.tick(TICK.load(aOrdering::Relaxed));
+                                }
+                            },
+                            Err(_) => {},
                         }
 
-                        TICK += TICK_STEP;
+                        TICK.store(
+                            tick + TICK_STEP.load(aOrdering::Relaxed),
+                            aOrdering::Relaxed,
+                        );
                     }
                     Ordering::Greater => {}
                     Ordering::Equal => {
-                        for d in DIMMER_DEVICES.iter_mut() {
-                            d.reset();
+                        match GLOBAL_DIMMER_INSTANCE.devices.try_borrow_mut() {
+                            Ok(mut devices) => {
+                                for d in devices.iter_mut() {
+                                    d.reset();
+                                }
+                            },
+                            Err(_) => {},
                         }
                     }
                 };
@@ -319,35 +335,60 @@ impl DevicesDimmerManager {
             ))?;
 
             // Create New device manager
-            DEVICES_DIMMER_MANAGER = Some(Self {
+            let mut manager = GLOBAL_DIMMER_INSTANCE.manager.borrow_mut();
+
+            *manager = Some(Self {
                 zero_crossing_pin: config.zero_crossing_pin,
                 esp_timer,
             });
 
-            Ok(DEVICES_DIMMER_MANAGER.as_mut().unwrap())
+            Ok(())
         }
     }
 }
 
 /// Set power of a device. The list of device is singleton.
 pub fn set_power(id: u8, power: u8) -> Result<(), RbdDimmerError> {
-    unsafe {
-        match DIMMER_DEVICES.iter_mut().find(|d| d.id == id) {
-            None => Err(RbdDimmerError::from(RbdDimmerErrorKind::DimmerNotFound)),
-            Some(device) => {
-                device.set_power(power);
-                Ok(())
+    match GLOBAL_DIMMER_INSTANCE.devices.try_borrow_mut() {
+        Ok(mut devices) => {
+            match devices.iter_mut().find(|d| d.id == id) {
+                Some(device) => {
+                    device.set_power(power);
+                    Ok(())
+                },
+                None => Err(RbdDimmerError::from(RbdDimmerErrorKind::DimmerNotFound)),
             }
-        }
+        },
+        Err(_) => Ok(()),
     }
 }
 
 /// Stop manager.
 pub fn stop() -> Result<bool, RbdDimmerError> {
-    unsafe {
-        match DEVICES_DIMMER_MANAGER.as_mut() {
-            Some(d) => d.stop(),
-            None => Ok(true)
-        }
+    match GLOBAL_DIMMER_INSTANCE.manager.try_borrow_mut() {
+        Ok(mut manager) => {
+            match manager.as_mut() {
+                Some(d) => d.stop(),
+                None => Err(RbdDimmerError::from(RbdDimmerErrorKind::DimmerManagerNotInit)),
+            }
+        },
+        Err(_) => Ok(false),
+    }
+}
+
+pub fn wait_zero_crossing() ->  Result<bool, RbdDimmerError> {
+    match GLOBAL_DIMMER_INSTANCE.manager.try_borrow_mut() {
+        Ok(mut manager) => {
+            match manager.as_mut() {
+                Some(d) => {
+                    match d.wait_zero_crossing() {
+                        Ok(()) => Ok(true),
+                        Err(e) => Err(e),
+                    }
+                },
+                None => Err(RbdDimmerError::from(RbdDimmerErrorKind::DimmerManagerNotInit)),
+            }
+        },
+        Err(_) => Ok(false),
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -52,9 +52,9 @@ pub mod zc;
 //
 // The ISR timer is always on.
 // When zero crossing is detected, we set IS_ZERO_CROSSING to true.
-// When IS_ZERO_CROSSING is true, ISR timer increase TICK from 0 to TICK_MAX (normaly
+// When IS_ZERO_CROSSING is true, ISR timer increase TICK from 0 to tick_max (normaly
 // 100 but in this case, we have collision with zero crossing detection).
-// The ISR timer call `tick()` method of each dimmer.
+// The ISR timer call `tick_manager()` method of each dimmer.
 //---------------------------------------------------------------------------------------
 
 // Duration of each percent cycle.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -307,7 +307,7 @@ impl DevicesDimmerManager {
                                 d.reset();
                             }
                         }
-                    },
+                    }
                 };
             };
 


### PR DESCRIPTION
The current ISR management for power is not very well.

It use `static mut` that will be deprecated in Rust 2024.
